### PR TITLE
CMake version update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 #  * @brief 		Main CMake module.
 # **/
 
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.14.4)
 
 # read and parse version from file VERSION
 file(READ "VERSION" VERSION_STRING)

--- a/lib/imu/CMakeLists.txt
+++ b/lib/imu/CMakeLists.txt
@@ -10,7 +10,7 @@
 #  * @brief 		CMake module for adimu library.
 # **/
 
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.14.4)
 
 add_library(adimu_s STATIC adi_imu_driver.c)
 target_include_directories(adimu_s PUBLIC .)

--- a/lib/imu_buf/CMakeLists.txt
+++ b/lib/imu_buf/CMakeLists.txt
@@ -10,7 +10,7 @@
 #  * @brief 		CMake module for adimubuf library.
 # **/
 
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.14.4)
 
 add_library(adimubuf_s STATIC imu_spi_buffer.c)
 target_include_directories(adimubuf_s PUBLIC .)

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -10,7 +10,7 @@
 #  * @brief 		CMake module for spi_driver and gpio_driver library.
 # **/
 
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.14.4)
 
 add_library(spi_driver STATIC spi_driver.c)
 if(DEBUG_SPI)


### PR DESCRIPTION
Requesting to update minimum CMake version.
1. Encountered during testing adrd2121_imu_ros2 in ROS2 Jazzy (Ubuntu 24.04)
2. Used CMake version in previous version is deprecated in Ubuntu 24.04 (see snap)
<img width="1536" height="864" alt="image" src="https://github.com/user-attachments/assets/0cd6e054-1077-4309-9a66-f5e5604c7c10" />
3. Minimum CMake version for ROS2 usage is 3.14.4. See reference here: https://docs.ros.org/en/humble/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html#cmake